### PR TITLE
Refactor: Use application coroutine scope

### DIFF
--- a/app/shared/src/commonMain/kotlin/com/melih/kmptemplate/di/Koin.kt
+++ b/app/shared/src/commonMain/kotlin/com/melih/kmptemplate/di/Koin.kt
@@ -6,11 +6,29 @@ import com.melih.kmptemplate.core.shared.logging.Klog
 import com.melih.kmptemplate.core.shared.logging.getKloggers
 import com.melih.kmptemplate.core.shared.model.platform.BuildType
 import com.melih.kmptemplate.core.shared.model.platform.Platform
+import com.melih.kmptemplate.core.shared.threading.DispatcherProvider
 import com.melih.kmptemplate.features.museum.api.di.museumFeatureModule
 import com.melih.kmptemplate.features.settings.api.di.settingsFeatureModule
 import com.melih.kmptemplate.platform.platformVersionName
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import org.koin.core.context.startKoin
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
+
+private val appModule = module {
+    single(named("applicationScope")) {
+        CoroutineScope(
+            DispatcherProvider.Main + SupervisorJob() + CoroutineExceptionHandler { _, error ->
+                Klog.error(
+                    tag = "ApplicationScope",
+                    throwable = error
+                ) { "Application scope error" }
+            }
+        )
+    }
+}
 
 private val platformModule = module {
     single<Platform> {
@@ -28,6 +46,7 @@ private val platformModule = module {
 fun initKoin() {
     val koinApp = startKoin {
         modules(
+            appModule,
             platformModule,
             dataModule,
             museumFeatureModule,

--- a/core/shared/data/src/commonMain/kotlin/com/melih/kmptemplate/core/shared/data/api/di/DataModule.kt
+++ b/core/shared/data/src/commonMain/kotlin/com/melih/kmptemplate/core/shared/data/api/di/DataModule.kt
@@ -6,6 +6,7 @@ import com.melih.kmptemplate.core.shared.data.internal.MuseumStorage
 import com.melih.kmptemplate.core.shared.domain.api.MuseumRepository
 import com.melih.kmptemplate.core.shared.network.api.MuseumApi
 import com.melih.kmptemplate.core.shared.network.api.di.networkModule
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val dataModule = module {
@@ -13,6 +14,6 @@ val dataModule = module {
 
     single<MuseumStorage> { InMemoryMuseumStorage() }
     single<MuseumRepository> {
-        DefaultMuseumRepository(get<MuseumApi>(), get())
+        DefaultMuseumRepository(get(named("applicationScope")), get<MuseumApi>(), get())
     }
 }

--- a/core/shared/data/src/commonMain/kotlin/com/melih/kmptemplate/core/shared/data/api/di/DataModule.kt
+++ b/core/shared/data/src/commonMain/kotlin/com/melih/kmptemplate/core/shared/data/api/di/DataModule.kt
@@ -13,8 +13,6 @@ val dataModule = module {
 
     single<MuseumStorage> { InMemoryMuseumStorage() }
     single<MuseumRepository> {
-        DefaultMuseumRepository(get<MuseumApi>(), get()).apply {
-            initialize()
-        }
+        DefaultMuseumRepository(get<MuseumApi>(), get())
     }
 }

--- a/core/shared/data/src/commonMain/kotlin/com/melih/kmptemplate/core/shared/data/internal/DefaultMuseumRepository.kt
+++ b/core/shared/data/src/commonMain/kotlin/com/melih/kmptemplate/core/shared/data/internal/DefaultMuseumRepository.kt
@@ -9,14 +9,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 internal class DefaultMuseumRepository(
+    applicationScope: CoroutineScope,
     private val museumApi: MuseumApi,
     private val museumStorage: MuseumStorage,
 ) : MuseumRepository {
 
-    private val scope = CoroutineScope(SupervisorJob())
-
     init {
-        scope.launch {
+        applicationScope.launch {
             refresh()
         }
     }

--- a/core/shared/data/src/commonMain/kotlin/com/melih/kmptemplate/core/shared/data/internal/DefaultMuseumRepository.kt
+++ b/core/shared/data/src/commonMain/kotlin/com/melih/kmptemplate/core/shared/data/internal/DefaultMuseumRepository.kt
@@ -15,7 +15,7 @@ internal class DefaultMuseumRepository(
 
     private val scope = CoroutineScope(SupervisorJob())
 
-    override fun initialize() {
+    init {
         scope.launch {
             refresh()
         }

--- a/core/shared/domain/src/commonMain/kotlin/com/melih/kmptemplate/core/shared/domain/api/MuseumRepository.kt
+++ b/core/shared/domain/src/commonMain/kotlin/com/melih/kmptemplate/core/shared/domain/api/MuseumRepository.kt
@@ -5,8 +5,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface MuseumRepository {
 
-    fun initialize()
-
     suspend fun refresh()
 
     fun getObjects(): Flow<List<MuseumObject>>


### PR DESCRIPTION
[**Qualifier** annotation](https://insert-koin.io/docs/reference/koin-core/qualifiers#jsr-330-qualifier) might be better option but right now, project doesn't support jsr annotations and no koin annotation usage yet as well. The main reason was to keep construction and operation separate from each other and keep project clean from DI solution. But I will further check whether it might be useful for documentation purposes and worth the risk. 